### PR TITLE
Fix some compiler warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,12 +96,12 @@ INSTALL_DIRECTORY( ./include DESTINATION . FILES_MATCHING PATTERN "*.h" )
 
 # ------- symlinks in include directory for backwards compatibility ---------
 # FIXME: this symlinks are needed to build Mokka. Should fix this code in Mokka
-INSTALL( CODE "EXECUTE_PROCESS( COMMAND ${CMAKE_COMMAND} -E create_symlink ${CMAKE_INSTALL_PREFIX}/include/gear/gearimpl ${CMAKE_INSTALL_PREFIX}/include/gearimpl )" )
-INSTALL( CODE "EXECUTE_PROCESS( COMMAND ${CMAKE_COMMAND} -E create_symlink ${CMAKE_INSTALL_PREFIX}/include/gear/gearxml ${CMAKE_INSTALL_PREFIX}/include/gearxml )" )
-INSTALL( CODE "EXECUTE_PROCESS( COMMAND ${CMAKE_COMMAND} -E create_symlink ${CMAKE_INSTALL_PREFIX}/include/gear/gearsurf ${CMAKE_INSTALL_PREFIX}/include/gearsurf )" )
+INSTALL( CODE "EXECUTE_PROCESS( COMMAND ${CMAKE_COMMAND} -E create_symlink gear/gearimpl gearimpl WORKING_DIRECTORY ${CMAKE_INSTALL_PREFIX}/include )" )
+INSTALL( CODE "EXECUTE_PROCESS( COMMAND ${CMAKE_COMMAND} -E create_symlink gear/gearxml gearxml WORKING_DIRECTORY ${CMAKE_INSTALL_PREFIX}/include )" )
+INSTALL( CODE "EXECUTE_PROCESS( COMMAND ${CMAKE_COMMAND} -E create_symlink gear/gearsurf gearsurf WORKING_DIRECTORY ${CMAKE_INSTALL_PREFIX}/include )" )
 
 IF( GEAR_TGEO )
-    INSTALL( CODE "EXECUTE_PROCESS( COMMAND ${CMAKE_COMMAND} -E create_symlink ${CMAKE_INSTALL_PREFIX}/include/gear/geartgeo ${CMAKE_INSTALL_PREFIX}/include/geartgeo )" )
+    INSTALL( CODE "EXECUTE_PROCESS( COMMAND ${CMAKE_COMMAND} -E create_symlink gear/geartgeo geartgeo WORKING_DIRECTORY ${CMAKE_INSTALL_PREFIX}/include)" )
 ENDIF()
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,12 +96,12 @@ INSTALL_DIRECTORY( ./include DESTINATION . FILES_MATCHING PATTERN "*.h" )
 
 # ------- symlinks in include directory for backwards compatibility ---------
 # FIXME: this symlinks are needed to build Mokka. Should fix this code in Mokka
-INSTALL( CODE "EXEC_PROGRAM( \"${CMAKE_COMMAND}\" \"${CMAKE_INSTALL_PREFIX}/include\" ARGS -E create_symlink gear/gearimpl gearimpl )" )
-INSTALL( CODE "EXEC_PROGRAM( \"${CMAKE_COMMAND}\" \"${CMAKE_INSTALL_PREFIX}/include\" ARGS -E create_symlink gear/gearxml gearxml )" )
-INSTALL( CODE "EXEC_PROGRAM( \"${CMAKE_COMMAND}\" \"${CMAKE_INSTALL_PREFIX}/include\" ARGS -E create_symlink gear/gearsurf gearsurf )" )
+INSTALL( CODE "EXECUTE_PROCESS( COMMAND ${CMAKE_COMMAND} -E create_symlink ${CMAKE_INSTALL_PREFIX}/include/gear/gearimpl ${CMAKE_INSTALL_PREFIX}/include/gearimpl )" )
+INSTALL( CODE "EXECUTE_PROCESS( COMMAND ${CMAKE_COMMAND} -E create_symlink ${CMAKE_INSTALL_PREFIX}/include/gear/gearxml ${CMAKE_INSTALL_PREFIX}/include/gearxml )" )
+INSTALL( CODE "EXECUTE_PROCESS( COMMAND ${CMAKE_COMMAND} -E create_symlink ${CMAKE_INSTALL_PREFIX}/include/gear/gearsurf ${CMAKE_INSTALL_PREFIX}/include/gearsurf )" )
 
 IF( GEAR_TGEO )
-    INSTALL( CODE "EXEC_PROGRAM( \"${CMAKE_COMMAND}\" \"${CMAKE_INSTALL_PREFIX}/include\" ARGS -E create_symlink gear/geartgeo geartgeo )" )
+    INSTALL( CODE "EXECUTE_PROCESS( COMMAND ${CMAKE_COMMAND} -E create_symlink ${CMAKE_INSTALL_PREFIX}/include/gear/geartgeo ${CMAKE_INSTALL_PREFIX}/include/geartgeo )" )
 ENDIF()
 
 

--- a/include/gear/GEAR.h
+++ b/include/gear/GEAR.h
@@ -48,6 +48,7 @@ namespace gear {
     
   public: 
     virtual ~Exception()  { /*no_op*/; } 
+    Exception( const Exception& e ) = default ;
     
     Exception( const std::string& text ){
       message = "gear::Exception: " + text ;

--- a/include/gear/TrackerPlanesLayerLayout.h
+++ b/include/gear/TrackerPlanesLayerLayout.h
@@ -23,8 +23,14 @@ class TrackerPlanesMaterialLayer  {
 
     
 public:
+    /// Constructor
+    TrackerPlanesMaterialLayer() = default;
+
     /// Destructor.
     virtual ~TrackerPlanesMaterialLayer() { /* nop */; }
+
+    /// Copy-constructor.
+    TrackerPlanesMaterialLayer( const TrackerPlanesMaterialLayer& ) = default;
 
     virtual int getID() const = 0;
 
@@ -136,8 +142,14 @@ class TrackerPlanesSensitiveLayer  {
 
     
 public:
+    /// Constructor
+    TrackerPlanesSensitiveLayer() = default;
+
     /// Destructor.
     virtual ~TrackerPlanesSensitiveLayer() { /* nop */; }
+
+    /// Copy-constructor.
+    TrackerPlanesSensitiveLayer( const TrackerPlanesSensitiveLayer& ) = default;
 
 
     /** ID of sensitive volume of layer layerIndex - layer indexing starts at 0
@@ -282,8 +294,15 @@ public:
 class TrackerPlanesLayer  {
 
 public:
+
+    /// Constructor
+    TrackerPlanesLayer() = default;
+
     /// Destructor.
     virtual ~TrackerPlanesLayer() { /* nop */; }
+
+    // Copy-constructor.
+    TrackerPlanesLayer( const TrackerPlanesLayer& ) = default;
 
     /** Layer ID of nonsensitive volume of layer layerIndex - layer indexing starts at 0
      *  for the layer closest to the beam source.*/

--- a/include/gear/gearimpl/FTDLayerLayoutImpl.h
+++ b/include/gear/gearimpl/FTDLayerLayoutImpl.h
@@ -26,7 +26,6 @@ class vframe  // TO BE DEPRECATED...
 		vframe(): x(0),y(0),z(0) { ; }
 		vframe(const double & xval, const double & yval, const double & zval):
 			x(xval),y(yval),z(zval) { ; }
-		~vframe() { ; }
 
 		double x{};
 		double y{};

--- a/include/gear/gearimpl/GearParametersImpl.h
+++ b/include/gear/gearimpl/GearParametersImpl.h
@@ -28,8 +28,13 @@ namespace gear {
     typedef std::map< std::string, StringVec > StringVecMap ;
 	
 	
+    GearParametersImpl() = default ;
+    GearParametersImpl(const GearParametersImpl&) = default ;
+    GearParametersImpl& operator = (const GearParametersImpl&) = default ;
+
     /// Destructor.
-    virtual ~GearParametersImpl() ;
+    virtual ~GearParametersImpl() = default ;
+
 	
     /** Integer value for key.     
      *  @throws UnknownParameterException

--- a/include/gear/gearimpl/GlobalPadIndex.h
+++ b/include/gear/gearimpl/GlobalPadIndex.h
@@ -19,7 +19,9 @@ protected:
 public:
 	
 	GlobalPadIndex(int padIndex, int moduleID);
-	virtual ~GlobalPadIndex();
+	virtual ~GlobalPadIndex() = default;
+        GlobalPadIndex(const GlobalPadIndex&) = default;
+        GlobalPadIndex& operator=(const GlobalPadIndex&) = default;
 
 	bool operator < (const  GlobalPadIndex & cmp) const
 	{

--- a/include/gear/gearimpl/TrackerPlanesLayerLayoutImpl.h
+++ b/include/gear/gearimpl/TrackerPlanesLayerLayoutImpl.h
@@ -53,6 +53,8 @@ class TrackerPlanesMaterialLayerImpl: public TrackerPlanesMaterialLayer  {
     /// Destructor.
     /**      */
     virtual ~TrackerPlanesMaterialLayerImpl() { /* nop */; }
+    /// Copy constructor.
+    TrackerPlanesMaterialLayerImpl(const TrackerPlanesMaterialLayerImpl&) = default;
     /**      */
     virtual int getID() const { return ID  ; }
     /**      */
@@ -158,6 +160,9 @@ class TrackerPlanesSensitiveLayerImpl: public TrackerPlanesSensitiveLayer   {
 
     /// Destructor.
     virtual ~TrackerPlanesSensitiveLayerImpl() { /* nop */; }
+
+    /// Copy constructor.
+    TrackerPlanesSensitiveLayerImpl(const TrackerPlanesSensitiveLayerImpl&) = default;
 
     /**      */
     virtual int getID() const { return ID  ; }
@@ -284,6 +289,9 @@ class TrackerPlanesLayerImpl: public TrackerPlanesLayer  {
     /** Destructor.
      */
     virtual ~TrackerPlanesLayerImpl() { /* nop */; }
+    /** Copy constructor.
+     */
+    TrackerPlanesLayerImpl(const TrackerPlanesLayerImpl&) = default;
 
     /** get methods
      */

--- a/include/gear/gearxml/GearParametersXML.h
+++ b/include/gear/gearxml/GearParametersXML.h
@@ -6,8 +6,6 @@
 
 #include "gearimpl/GearParametersImpl.h"
 
-#include <string>
-
 
 namespace gear {
   

--- a/src/gearimpl/FTDLayerLayoutImpl.cc
+++ b/src/gearimpl/FTDLayerLayoutImpl.cc
@@ -226,7 +226,7 @@ double FTDLayerLayoutImpl::getThicknessForAngle(const int & layerIndex,const dou
 	//                  -si entra por el petalo
 	//                  -cual es la distancia que recorre antes de salir
 	//                  -para ello hay que controlar si sale antes de que
-	//                   acabe el petalo, en Y es fácil pero en x, al ser
+	//                   acabe el petalo, en Y es facil pero en x, al ser
 	//                   un petalo, la distancia es variable y dependera
 	//                   de la zona Y de salida del rayo
 	//                  -controlar y prohibir angulos que no esten en

--- a/src/gearimpl/FixedPadSizeDiskLayout.cc
+++ b/src/gearimpl/FixedPadSizeDiskLayout.cc
@@ -173,7 +173,7 @@ namespace gear {
       return _padWidth / _rows.at( rowNum ).RCenter ;
 
     }
-    catch(std::out_of_range){
+    catch(std::out_of_range const&){
       return 0. ;
     }
   }
@@ -188,7 +188,7 @@ namespace gear {
 	return _rows.at( rowNum ).PhiPad;
 
     }
-    catch(std::out_of_range){
+    catch(std::out_of_range const&){
       return 0. ;
     }
   }

--- a/src/gearimpl/GearMgrImpl.cc
+++ b/src/gearimpl/GearMgrImpl.cc
@@ -467,7 +467,7 @@ namespace gear{
 
       lcalParameters->getDoubleVal("beam_crossing_angle") ;
 
-    }catch( UnknownParameterException ){
+    }catch( UnknownParameterException const& ){
 
       std::cout << "WARNING GearMgrImpl::setLcalParameters: added "
 	" missing parameter beam_crossing_angle 0.0 ! " << std::endl ;
@@ -488,7 +488,7 @@ namespace gear{
 
       lhcalParameters->getDoubleVal("beam_crossing_angle") ;
 
-    }catch( UnknownParameterException ){
+    }catch( UnknownParameterException const& ){
 
     std::cout << "WARNING GearMgrImpl::setLHcalParameters: added "
 	" missing parameter beam_crossing_angle 0.0 ! " << std::endl ;
@@ -509,7 +509,7 @@ namespace gear{
 
       beamcalParameters->getDoubleVal("beam_crossing_angle") ;
 
-    }catch( UnknownParameterException ){
+    }catch( UnknownParameterException const& ){
 
       std::cout << "WARNING GearMgrImpl::setBeamCalParameters: added "
 	" missing parameter beam_crossing_angle 0.0 ! " << std::endl ;

--- a/src/gearimpl/GearParametersImpl.cc
+++ b/src/gearimpl/GearParametersImpl.cc
@@ -1,10 +1,6 @@
 #include "gearimpl/GearParametersImpl.h"
 
-#include <algorithm>
-
 namespace gear{
-  
-  GearParametersImpl::~GearParametersImpl() { /* nop */; }
   
   int GearParametersImpl::getIntVal(const std::string & key) const {
     

--- a/src/gearimpl/GlobalPadIndex.cc
+++ b/src/gearimpl/GlobalPadIndex.cc
@@ -6,8 +6,6 @@ namespace gear {
 	_padIndex( padIndex) ,
 	_moduleID (moduleID) {
     }
-    GlobalPadIndex::~GlobalPadIndex(){
-    }
     int GlobalPadIndex::getPadIndex() const {
 	return _padIndex;
     }

--- a/src/gearimpl/TPCParametersImpl.cc
+++ b/src/gearimpl/TPCParametersImpl.cc
@@ -78,7 +78,7 @@ namespace gear {
 
 	// call the assignment operator of the GearParametersImpl mother class:
 	// *dynamic_cast<GearParametersImpl*>(this) = *dynamic_cast<GearParametersImpl const *>(&right);
-	GearParametersImpl::operator = (right);
+        this->operator = (right);
     }
 
     /// Destructor.

--- a/src/gearxml/GearParametersXML.cc
+++ b/src/gearxml/GearParametersXML.cc
@@ -233,7 +233,7 @@ namespace gear {
 	
 	value = getXMLAttribute( par , "value" )  ; 
       }      
-      catch( ParseException ) {
+      catch( ParseException const& ) {
 	
 	if( par->FirstChild() )
 	  value =  par->FirstChild()->Value() ;

--- a/src/gearxml/GearParametersXML.cc
+++ b/src/gearxml/GearParametersXML.cc
@@ -50,9 +50,6 @@ namespace gear {
       
     } 
     
-    ~Tokenizer(){
-    }
-    
     std::vector<std::string> & result()  { 
       
       return _tokens ; 

--- a/src/gearxml/GearXML.cc
+++ b/src/gearxml/GearXML.cc
@@ -68,7 +68,7 @@ namespace gear{
 
     try{   detName = mgr->getDetectorName()  ;
     }
-    catch( UnknownParameterException ){}
+    catch( UnknownParameterException const& ){}
 
     global.SetAttribute( "detectorName" , detName ) ;
     

--- a/src/gearxml/RectangularPadRowLayoutXML.cc
+++ b/src/gearxml/RectangularPadRowLayoutXML.cc
@@ -85,8 +85,6 @@ namespace gear {
     RectangularPadRowLayout* padRowLayout = new RectangularPadRowLayout( xMin, xMax, yMin ) ;
 
     // ----- rows ------------
-    int rowId = 0 ;
-
     const TiXmlNode* row = 0 ;
     while( ( row = xmlElement->IterateChildren( "row", row ) )  != 0  ){
 
@@ -103,7 +101,6 @@ namespace gear {
       
       padRowLayout->addRow( nRow, nPad, padWidth, padHeight, rowHeight, leftOffset, rightOffset ) ;
 	
-      rowId+= nRow ;
     }
 
     padRowLayout->repeatRows( repeatRowCount ) ;

--- a/src/gearxml/tinyxmlparser.cc
+++ b/src/gearxml/tinyxmlparser.cc
@@ -110,14 +110,17 @@ void TiXmlBase::ConvertUTF32ToUTF8( unsigned long input, char* output, int* leng
 			--output; 
 			*output = (char)((input | BYTE_MARK) & BYTE_MASK); 
 			input >>= 6;
+                        [[fallthrough]];
 		case 3:
 			--output; 
 			*output = (char)((input | BYTE_MARK) & BYTE_MASK); 
 			input >>= 6;
+                        [[fallthrough]];
 		case 2:
 			--output; 
 			*output = (char)((input | BYTE_MARK) & BYTE_MASK); 
 			input >>= 6;
+                        [[fallthrough]];
 		case 1:
 			--output; 
 			*output = (char)(input | FIRST_BYTE_MARK[*length]);

--- a/src/test/testgear.cc
+++ b/src/test/testgear.cc
@@ -239,12 +239,14 @@ void testFixedPadSizeDiskLayout( const  FixedPadSizeDiskLayout& pl ) {
       // in the other implementations, because there are pads at the edge of the pad plane
       // which have no neighbour.
       if( j == 0 ) {
-	pl.getRightNeighbour(  pl.getPadIndex( iRow , iPad ) ) ; 
+	int ln = pl.getRightNeighbour(  pl.getPadIndex( iRow , iPad ) ) ; 
+        (void) ln ;
 	assert(  pl.getPadNumber( ln ) ==  nPad-1 ) ;
       }
 
       if( j == nPad-1 ) {
-	pl.getLeftNeighbour(  pl.getPadIndex( iRow , iPad ) ) ; 
+	int rn = pl.getLeftNeighbour(  pl.getPadIndex( iRow , iPad ) ) ; 
+        (void) rn ;
 	assert(  pl.getPadNumber( rn ) ==  0 ) ;
       }
 

--- a/src/test/testgear.cc
+++ b/src/test/testgear.cc
@@ -239,12 +239,12 @@ void testFixedPadSizeDiskLayout( const  FixedPadSizeDiskLayout& pl ) {
       // in the other implementations, because there are pads at the edge of the pad plane
       // which have no neighbour.
       if( j == 0 ) {
-	int ln = pl.getRightNeighbour(  pl.getPadIndex( iRow , iPad ) ) ; 
+	pl.getRightNeighbour(  pl.getPadIndex( iRow , iPad ) ) ; 
 	assert(  pl.getPadNumber( ln ) ==  nPad-1 ) ;
       }
 
       if( j == nPad-1 ) {
-	int rn = pl.getLeftNeighbour(  pl.getPadIndex( iRow , iPad ) ) ; 
+	pl.getLeftNeighbour(  pl.getPadIndex( iRow , iPad ) ) ; 
 	assert(  pl.getPadNumber( rn ) ==  0 ) ;
       }
 

--- a/src/test/testtpcproto.cc
+++ b/src/test/testtpcproto.cc
@@ -156,14 +156,14 @@ void testRectangularPadRowLayout( const  RectangularPadRowLayout& pl ) {
       
       if( j != 0 ) {
 
- 	int ln = pl.getLeftNeighbour(  pl.getPadIndex( iRow , iPad ) ) ; 
+ 	pl.getLeftNeighbour(  pl.getPadIndex( iRow , iPad ) ) ; 
 
  	assert(  pl.getPadNumber( ln ) ==  iPad - 1 ) ;
       }
 
       if( j != nPad-1 ) {
 
-	int rn = pl.getRightNeighbour(  pl.getPadIndex( iRow , iPad ) ) ; 
+	pl.getRightNeighbour(  pl.getPadIndex( iRow , iPad ) ) ; 
 
  	assert(  pl.getPadNumber( rn )  ==  iPad + 1 ) ;
       }

--- a/src/test/testtpcproto.cc
+++ b/src/test/testtpcproto.cc
@@ -156,14 +156,16 @@ void testRectangularPadRowLayout( const  RectangularPadRowLayout& pl ) {
       
       if( j != 0 ) {
 
- 	pl.getLeftNeighbour(  pl.getPadIndex( iRow , iPad ) ) ; 
+ 	int ln = pl.getLeftNeighbour(  pl.getPadIndex( iRow , iPad ) ) ; 
+        (void) ln ;
 
  	assert(  pl.getPadNumber( ln ) ==  iPad - 1 ) ;
       }
 
       if( j != nPad-1 ) {
 
-	pl.getRightNeighbour(  pl.getPadIndex( iRow , iPad ) ) ; 
+	int rn = pl.getRightNeighbour(  pl.getPadIndex( iRow , iPad ) ) ; 
+        (void) rn ;
 
  	assert(  pl.getPadNumber( rn )  ==  iPad + 1 ) ;
       }


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix warnings about not passing exceptions by reference
- Fix warnings about an implicit copy constructor defined
- Fix other warnings, about fallthroughs, a weird UTF-8 character (spanish accent in comments in spanish) and unused results

ENDRELEASENOTES

The fallthroughs I'm not sure if they are intended but I just left the current behavior...