### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/key4hep.yaml
+++ b/.github/workflows/key4hep.yaml
@@ -1,0 +1,34 @@
+name: key4hep
+
+on: [push, pull_request]
+
+jobs:
+  linux:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - release: "sw.hsf.org/key4hep"
+            CXX_STANDARD: 17
+          - release: "sw-nightlies.hsf.org/key4hep"
+            CXX_STANDARD: 20
+    steps:
+    - uses: actions/checkout@v3
+    - uses: cvmfs-contrib/github-action-cvmfs@v3
+    - uses: aidasoft/run-lcg-view@v4
+      with:
+        container: centos7
+        view-path: /cvmfs/${{ matrix.release }}
+        run: |
+          mkdir build install
+          cd build
+          cmake -DCMAKE_CXX_STANDARD=${{ matrix.CXX_STANDARD }} \
+            -DCMAKE_CXX_FLAGS="-fdiagnostics-color=always " \
+            -DCMAKE_INSTALL_PREFIX=../install \
+            -DINSTALL_DOC=ON \
+            -GNinja \
+            ..
+          ninja -k0
+          ctest --output-on-failure
+          ninja install

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -7,12 +7,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        COMPILER: [gcc10, clang11]
-        LCG: [100]
-        include:
-          - COMPILER: gcc8
-            LCG: 99python2
-
+        COMPILER: [gcc11]
+        LCG: [104]
     steps:
     - uses: actions/checkout@v2
     - uses: cvmfs-contrib/github-action-cvmfs@v2


### PR DESCRIPTION

BEGINRELEASENOTES
- Remove no longer working gcc8 based workflow
- Update github actions versions
- Add key4hep based workflow

ENDRELEASENOTES