### PR TITLE
Include GNUInstallDirs to set CMAKE_INSTALL_LIBDIR for MacOS builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,8 @@ SET( ${PROJECT_NAME}_VERSION_MAJOR 1 )
 SET( ${PROJECT_NAME}_VERSION_MINOR 9 )
 SET( ${PROJECT_NAME}_VERSION_PATCH 3 )
 
+include(GNUInstallDirs)
+
 cmake_policy(SET CMP0008 NEW)
 
 ### DEPENDENCIES ############################################################


### PR DESCRIPTION
Include GNUInstallDirs in CMakeLists.txt


BEGINRELEASENOTES
- Add GNUInstallDirs to set CMAKE_INSTALL_LIBDIR so that the default rpath is correct and can be used in downstream projects, like in `k4MarlinWrapper`

ENDRELEASENOTES

See https://github.com/iLCSoft/Marlin/pull/62