### PR TITLE
Fix apparent off-by-one error.

### DIFF
--- a/src/gearimpl/TPCParametersImpl.cc
+++ b/src/gearimpl/TPCParametersImpl.cc
@@ -277,7 +277,7 @@ namespace gear {
 	double shortest_distance = (*itr)->getDistanceToPad( c0, c1, closest_pad.getPadIndex() );
 
 	// start at the second module
-	for( itr+1; itr!=modulesVector.end(); itr++) {
+	for( ++itr; itr!=modulesVector.end(); itr++) {
 
 		GlobalPadIndex temp_pad( (*itr)->getNearestPad( c0, c1 ), (*itr)->getModuleID() );
 


### PR DESCRIPTION
In this line

```
	// start at the second module
	for( itr+1; itr!=modulesVector.end(); itr++) {
```

the initialization section is a no-op.  From the comment, it appears that the intent was to increment itr.  Fixed.

This fixes a warning seen with gcc15.



BEGINRELEASENOTES
- Fix apparent off-by-one error in TPCParametersImpl::getNearestPad.
ENDRELEASENOTES