### PR TITLE
Add LANGUAGES CXX to the top level CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@ CMAKE_MINIMUM_REQUIRED(VERSION 3.5 FATAL_ERROR)
 
 
 # project name
-PROJECT( GEAR )
+PROJECT( GEAR LANGUAGES CXX )
 
 
 # project version


### PR DESCRIPTION
BEGINRELEASENOTES
- Add LANGUAGES CXX to the top level CMakeLists.txt to disable checks for a C compiler

ENDRELEASENOTES