### PR TITLE
Fix clang warnings.

### DIFF
--- a/src/geartgeo/MaterialMap.cc
+++ b/src/geartgeo/MaterialMap.cc
@@ -194,7 +194,6 @@ namespace gear {
     if(_zmin<=pz[1] && pz[1]<=_zmax)
       zcount++;
     //calculate distances from x,y,z to each neighbour
-    int counter=0;
     double sumIntL=0,sumRadL=0,sumWeight=0;
     bool isOnGrid=false;
     for(int ix=0;ix<xcount;ix++)
@@ -207,7 +206,6 @@ namespace gear {
 		std::vector<int>  gpos;
 		calculateGridIndex(gpos,px[ix],py[iy],pz[iz]);
 		std::pair<double,double> vals=_myMap[gpos[0]][gpos[1]][gpos[2]];
-		counter++;
 		if(fabs(d)<1e-5)//point in querry is a grid point
 		  {
 		    sumRadL=vals.first;

--- a/src/geartgeo/TGeoGearPointProperties.cc
+++ b/src/geartgeo/TGeoGearPointProperties.cc
@@ -174,7 +174,6 @@ namespace gear {
       throw OutsideGeometryException("No geometry node found at given location. Either there is no node placed here or position is outside of top volume.");
     
     TGeoVolume *cvol=_tgeomanager->GetCurrentVolume();
-    int count=0;
     while(cvol)
       {
 	const char *name=cvol->GetName();
@@ -183,7 +182,6 @@ namespace gear {
 	cvol=_tgeomanager->GetCurrentVolume();
 	if(name==_tgeomanager->GetTopVolume()->GetName())
 	  break;
-	count++;
       }
     return names;
   }
@@ -201,7 +199,6 @@ namespace gear {
     if(!node)
       throw OutsideGeometryException("No geometry node found at given location. Either there is no node placed here or position is outside of top volume.");
     
-    int count=0;
     while(node)
       {
 	const char *name=node->GetName();
@@ -210,7 +207,6 @@ namespace gear {
 	node=_tgeomanager->GetCurrentNode();
 	if(name==_tgeomanager->GetTopNode()->GetName())
 	  break;
-	count++;
       }
     return names;
   }

--- a/src/test/testgear.cc
+++ b/src/test/testgear.cc
@@ -1,4 +1,4 @@
-
+#undef NDEBUG
 #include "gearimpl/FixedPadSizeDiskLayout.h"
 #include "gearimpl/Util.h"
 #include "gearxml/GearXML.h"

--- a/src/test/testtpcproto.cc
+++ b/src/test/testtpcproto.cc
@@ -1,3 +1,4 @@
+#undef NDEBUG
 #include "gearimpl/RectangularPadRowLayout.h"
 #include "gearimpl/Util.h"
 #include "gearxml/GearXML.h"


### PR DESCRIPTION
Unused variables.

BEGINRELEASENOTES
- Fix some unused variable warnings seen when compiling with clang.
ENDRELEASENOTES