### PR TITLE
Update minimum cmake version to 3.10.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 ########################################################
 # cmake file for building GEAR
 # @author Jan Engels, Desy IT
-CMAKE_MINIMUM_REQUIRED(VERSION 3.5 FATAL_ERROR)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.10 FATAL_ERROR)
 ########################################################
 
 


### PR DESCRIPTION
Get rid of cmake deprecation warning.

BEGINRELEASENOTES
- Update minimum cmake version to 3.10.
ENDRELEASENOTES